### PR TITLE
Added fps timer, fixed object positioning,added speed limiter

### DIFF
--- a/src/SGL/Object.cpp
+++ b/src/SGL/Object.cpp
@@ -46,6 +46,19 @@ Vector Object::getVelocity() const
 void Object::setVelocity(const Vector &value)
 {
 	velocity = value;
+
+    //limit our speed
+    if(velocity.x>maxSpeed)
+        velocity.x=maxSpeed;
+
+    if(velocity.y>maxSpeed)
+        velocity.y=maxSpeed;
+
+    if(velocity.x<-maxSpeed)
+        velocity.x=-maxSpeed;
+
+    if(velocity.y<-maxSpeed)
+        velocity.y=-maxSpeed;
 }
 
 void Object::setVelocity(double x, double y)
@@ -60,7 +73,7 @@ void Object::move(const Vector &value)
 
 void Object::applyForce(const Vector &force, double time)
 {
-	velocity = velocity + (force / mass) * time;
+    setVelocity(getVelocity()+(force / mass) * time);  //in order to limit speed
 }
 
 void Object::applyForce(double forceX, double forceY, double time)

--- a/src/SGL/Object.hpp
+++ b/src/SGL/Object.hpp
@@ -14,6 +14,8 @@ private:
 	double mass;
 	bool static_ = false;
 
+    const double maxSpeed=0.3; //speed limiter,needs to be changed
+
 	void step(const double time);
 
 public:

--- a/src/TestEvironment/GObject.cpp
+++ b/src/TestEvironment/GObject.cpp
@@ -1,10 +1,11 @@
 #include "GObject.hpp"
 
 GObject::GObject(QPointF point, QObject *parent):
-	QObject(parent), QGraphicsEllipseItem(point.x()-10, point.y()-10, 20, 20)
+    QObject(parent), QGraphicsEllipseItem(0, 0, 20, 20) //rect of the object
 {
 	object = new sgl::Object(200);
-	object->setPosition(point.x(), point.y());
+    object->setPosition(point.x()-10,point.y()-10); //we substract 10 to place center of cirlce in point coords
+    setPos(point.x()-10,point.y()-10);
 
 	QBrush brush;
 	brush.setStyle(Qt::SolidPattern);
@@ -21,8 +22,8 @@ GObject::~GObject()
 void GObject::paint(QPainter *painter,
 	const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
-	this->setX(this->object->getPosition().x);
-	this->setY(this->object->getPosition().y);
+    qDebug()<<"Repaint GObject";
+    this->setPos(this->object->getPosition().x,this->object->getPosition().y);
 
 	QGraphicsEllipseItem::paint(painter, option, widget);
 }

--- a/src/TestEvironment/GObject.hpp
+++ b/src/TestEvironment/GObject.hpp
@@ -6,6 +6,7 @@
 #include <QGraphicsScene>
 #include <QBrush>
 #include <QPen>
+#include <QDebug>
 
 #include "SGL/Gravity.hpp"
 

--- a/src/TestEvironment/Scene.cpp
+++ b/src/TestEvironment/Scene.cpp
@@ -17,21 +17,22 @@ Scene::~Scene()
 
 }
 
-void Scene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
+void Scene::createObject(QPointF initCords)
 {
-	//here comes kostil
-	GObject *object = new GObject(mouseEvent->scenePos(), (Scene*) this);
-	this->addItem(object);
+    GObject *object = new GObject(initCords, (Scene*) this); //create object and place it to our initCords
+    this->addItem(object);
 
-	this->curObj = object->object;
-	this->prevPos = mouseEvent->pos();
+    this->curObj = object->object;
+    this->prevPos = initCords;
 }
 
-void Scene::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent)
+void Scene::setObjectSpeed(QPointF releaseCords)
 {
-	auto v = (prevPos - mouseEvent->pos()) / 5; //magic
+    auto v = (prevPos - releaseCords) / startingSpeedKoef;
 
-	this->curObj->setVelocity(v.x(), v.y());
+    qDebug()<<"Mouse released "<<v.x()<<" "<<v.y();
 
-	this->world.addObject(curObj);
+    this->curObj->setVelocity(v.x(), v.y());
+
+    this->world.addObject(curObj);
 }

--- a/src/TestEvironment/Scene.hpp
+++ b/src/TestEvironment/Scene.hpp
@@ -15,12 +15,13 @@ public:
 	explicit Scene(QObject *parent = nullptr);
 	~Scene();
 
-	void mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent) override;
-	void mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent) override;
+    void createObject(QPointF initCords);
+    void setObjectSpeed(QPointF releaseCords);
 
 	sgl::World world;
 
 private:
+    const int startingSpeedKoef=500000;
 	QPointF prevPos;
 	sgl::Object *curObj;
 };

--- a/src/TestEvironment/View.cpp
+++ b/src/TestEvironment/View.cpp
@@ -3,9 +3,14 @@
 View::View(QWidget *parent) :
 	  QGraphicsView(parent)
 {
-	scene = new Scene(this);
+    scene = new Scene(this);
+    scene->setSceneRect(0,0,1000,1000); //necessary to have stable coordinates
+    this->setScene(scene);
 
-	this->setScene(scene);
+    timer=new QTimer(this);  //timer for controlling fps
+    connect(timer,SIGNAL(timeout()),this,SLOT(worldStep()));     //when timer emit timeout, we make world step. So that we have stable intervals between world steps
+    timer->setInterval(5);  //controlling fps(now we have 20 frames per second)
+    timer->start(5);
 }
 
 View::~View()
@@ -13,9 +18,33 @@ View::~View()
 
 }
 
+void View::mousePressEvent(QMouseEvent *mouseEvent)
+{
+    //kostil is probably fixed
+    QPointF clickPoint=mapToScene(mouseEvent->pos());  //get correct coords of click regarding to graphicsScene
+
+    qDebug()<<"Mouse pressed "<<mouseEvent->pos().x()<<" "<<mouseEvent->pos().y();   //where we pressed regarding to graphicsView
+    qDebug()<<"Map to scene: "<<clickPoint.x()<<" "<<clickPoint.y();                 //where we pressed regarding to graphicsScene
+
+    scene->createObject(clickPoint);                                                 //create GObject in clickpoint coords
+}
+
+void View::mouseReleaseEvent(QMouseEvent *mouseEvent)
+{
+    QPointF clickPoint=mapToScene(mouseEvent->pos()); //get correct coords of click regarding to graphicsScene
+
+    scene->setObjectSpeed(clickPoint);  //set starting speed for our object
+
+}
+
 void View::paintEvent(QPaintEvent *event)
 {
 	QGraphicsView::paintEvent(event);
+}
 
-	this->scene->world.step(50000); //magic constant
+void View::worldStep()   //here we do worldStep
+{
+    scene->world.step(5000);
+    scene->update();       //update scene to repaint GObjects
+    qDebug()<<"World step";
 }

--- a/src/TestEvironment/View.hpp
+++ b/src/TestEvironment/View.hpp
@@ -2,6 +2,9 @@
 #define VIEW_HPP
 
 #include <QGraphicsView>
+#include <QTimer>
+#include <QMouseEvent>
+#include <QDebug>
 
 #include "Scene.hpp"
 
@@ -13,9 +16,15 @@ public:
 	explicit View(QWidget *parent = nullptr);
 	~View();
 
-	void paintEvent(QPaintEvent *event) override;
+    void mousePressEvent(QMouseEvent *mouseEvent); //we do it in graphicsView to get correct coordinates for scene
+    void mouseReleaseEvent(QMouseEvent *mouseEvent);
+    void paintEvent(QPaintEvent *event) override;
+
+public slots:
+    void worldStep();
 
 private:
+    QTimer *timer;//timer for controlling fps
 	Scene *scene;
 };
 


### PR DESCRIPTION
This is my first pull request in github)
Changes:
-Replaced mousePress and mouseReleased events from Scene to View. In order to use mapToScene function to get correct coordinates of clicking. But all work with objects is still in Scene.
-Added timer in View. When we set timer's interval we controll fps of simulation
-Added speed limiter in Object. Speed limiter needs to be set, because when two objects are very close, their R is very small and hence, their velocity is very big. Because of this, they move too fast.